### PR TITLE
Import gcd for python 3.10

### DIFF
--- a/commpy/channelcoding/algcode.py
+++ b/commpy/channelcoding/algcode.py
@@ -2,9 +2,11 @@
 
 # Authors: Veeresh Taranalli <veeresht@gmail.com>
 # License: BSD 3-Clause
-
-#from fractions import gcd
-from math import gcd
+import sys
+if sys.version_info[:2] > (3,9):
+    from math import gcd
+else:
+    from fractions import gcd
 from numpy import array, arange, concatenate, convolve
 
 from commpy.channelcoding.gfields import GF, polymultiply, poly_to_string

--- a/commpy/channelcoding/algcode.py
+++ b/commpy/channelcoding/algcode.py
@@ -3,7 +3,8 @@
 # Authors: Veeresh Taranalli <veeresht@gmail.com>
 # License: BSD 3-Clause
 
-from fractions import gcd
+#from fractions import gcd
+from math import gcd
 from numpy import array, arange, concatenate, convolve
 
 from commpy.channelcoding.gfields import GF, polymultiply, poly_to_string

--- a/commpy/channelcoding/gfields.py
+++ b/commpy/channelcoding/gfields.py
@@ -5,7 +5,8 @@
 
 """ Galois Fields """
 
-from fractions import gcd
+#from fractions import gcd
+from math import gcd
 from numpy import array, zeros, arange, convolve, ndarray, concatenate
 from itertools import *
 from commpy.utilities import dec2bitarray, bitarray2dec

--- a/commpy/channelcoding/gfields.py
+++ b/commpy/channelcoding/gfields.py
@@ -4,9 +4,11 @@
 # License: BSD 3-Clause
 
 """ Galois Fields """
-
-#from fractions import gcd
-from math import gcd
+import sys
+if sys.version_info[:2] > (3,9):
+    from math import gcd
+else:
+    from fractions import gcd
 from numpy import array, zeros, arange, convolve, ndarray, concatenate
 from itertools import *
 from commpy.utilities import dec2bitarray, bitarray2dec


### PR DESCRIPTION
## Issue
For python 3.10, gcd function is in the math module, and no longer in the fractions module. An import error occurs if it's run by a python version larger than 3.9. 

## Solution
An if statement is added in the import part. 

